### PR TITLE
Do not trash nodes created via responseData

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -130,13 +130,13 @@ function render () {
           <td class="origin"><a href=${item.url}>${new URL(item.url).origin}</a></td>
           ${acceptEncodingTypes.map(type => {
             const responseData = item[type];
-            if (responseData.err) return hyperHTML.wire(responseData)`
+            if (responseData.err) return hyperHTML.wire(responseData, ':single')`
               <td colspan=2 class="unexpected">Err</td>
             `;
 
             const unexpectedEncoding = type.startsWith('acceptIdentity') && responseData.encoding;
 
-            return hyperHTML.wire(responseData)`
+            return hyperHTML.wire(responseData, ':double')`
               <td class="${responseData.status !== 206 ? 'unexpected' : ''}">${responseData.status}</td>
               <td class="${unexpectedEncoding ? 'unexpected' : ''}">${responseData.encoding || ''}</td>
             `;


### PR DESCRIPTION
This is an interesting demo (performance speaking) and one tiny thing I've spotted (that won't solve much) is that you are trashing, if data changes, nodes related to `responseData`.

I will try to investigate more on how to speed up rendering of those 8000+ rows, for now please consider this maybe little improvement.